### PR TITLE
Replace PhpCsFixer\Config::create() with a config instance

### DIFF
--- a/web/Export/PhpCsExporter.ts
+++ b/web/Export/PhpCsExporter.ts
@@ -30,7 +30,8 @@ export default class PhpCsExporter implements ExporterInterface {
             ' * https://mlocati.github.io/php-cs-fixer-configurator/#version:' + configuration.version + '|configurator',
             ' * you can change this configuration by importing this file.',
             ' */',
-            'return PhpCsFixer\\Config::create()'
+            '$config = new PhpCsFixer\\Config();',
+            'return $config'
         ];
         if (configuration.risky) {
             lines.push(INDENT + '->setRiskyAllowed(true)');


### PR DESCRIPTION
The create() method has been deprecated since PHP-CS-Fixer v2.17, and removed in v3.0.0.