### PR TITLE
Update PhpCsExporter.ts

### DIFF
--- a/web/Export/PhpCsExporter.ts
+++ b/web/Export/PhpCsExporter.ts
@@ -73,7 +73,6 @@ export default class PhpCsExporter implements ExporterInterface {
         }
         lines.push(INDENT + '])');
         lines.push(INDENT + '->setFinder(PhpCsFixer\\Finder::create()');
-        lines.push(INDENT + INDENT + '->exclude(\'vendor\')');
         lines.push(INDENT + INDENT + '->in(__DIR__)');
         lines.push(INDENT + ')');
         lines.push(';');


### PR DESCRIPTION
Is this needed at all?
Fixer is ignoring vendor by default for ~7yrs
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blame/master/src/Finder.php#L32