### PR TITLE
Laravel Pint compatible json export

### DIFF
--- a/web/Export/Exporters.ts
+++ b/web/Export/Exporters.ts
@@ -5,6 +5,7 @@ import PhpECSExporter from "./PhpECSExporter";
 import StyleCIExporter from "./StyleCIExporter";
 import YamlExporter from "./YamlExporter";
 import PhpArrayExporter from "./PhpArrayExporter";
+import LaravelPintExporter from "./LaravelPintExporter";
 
 const Exporters: ExporterInterface[] = [
     new PhpCsExporter(),
@@ -13,6 +14,7 @@ const Exporters: ExporterInterface[] = [
     new YamlExporter(),
     new StyleCIExporter(),
     new PhpArrayExporter(),
+    new LaravelPintExporter(),
 ];
 
 export default Exporters;

--- a/web/Export/LaravelPintExporter.ts
+++ b/web/Export/LaravelPintExporter.ts
@@ -1,0 +1,36 @@
+import ExporterInterface, { RenderOptions } from "./ExporterInterface";
+import { SerializedConfigurationInterface } from "../Configuration";
+
+export default class LaravelPintExporter implements ExporterInterface {
+    readonly handle: string = 'laravel-pint';
+
+    readonly language: string = 'json';
+
+    readonly name: string = 'Laravel Pint';
+
+    readonly supportConfiguringWhitespace: boolean = false;
+
+    readonly supportFixerDescriptions: boolean = false;
+
+    render(configuration: SerializedConfigurationInterface, options: RenderOptions): string {
+        const converted: { preset: string | undefined, rules: undefined | object } = {
+            preset: undefined,
+            rules: configuration.fixers
+        };
+
+        if (configuration.fixerSets !== undefined) {
+            if (configuration.fixerSets.length > 1) {
+                throw new Error('Laravel Pint supports up to 1 preset; Try to expand them');
+            }
+
+            if (!['@Symfony', '@PER', '@PSR12'].includes(configuration.fixerSets[0])) {
+                throw new Error('Laravel Pint only supports the following presets: psr12, symfony, per; Try to expand them');
+            }
+
+            converted.preset = configuration.fixerSets[0].substr(1).toLowerCase();
+        }
+
+        return JSON.stringify(converted, null, 4);
+    }
+
+}


### PR DESCRIPTION
Hey,

Since this configuration site is lately pinned on the Laravel documentation as a [recommended configuration tool for Pint](https://laravel.com/docs/10.x/pint#rules) we should include and export for that.

I tried to follow your code style and recommendations from the `README.md`.